### PR TITLE
refactor: :recycle: change search to textbox to be more accessible

### DIFF
--- a/_extensions/sdca-theme/_extension.yml
+++ b/_extensions/sdca-theme/_extension.yml
@@ -20,7 +20,7 @@ contributes:
       repo-actions: [edit, issue, source]
       search:
         location: navbar
-        type: overlay
+        type: textbox
       page-footer:
         center:
           - text: "License: CC BY 4.0"


### PR DESCRIPTION
The overlay option doesn't seem to include an accessible name for the search button which is a problem for people using screen readers. Using the textbox option avoids that.