### PR TITLE
chore: :fire: remove twitter link in navbar

### DIFF
--- a/_extensions/sdca-theme/_extension.yml
+++ b/_extensions/sdca-theme/_extension.yml
@@ -23,9 +23,6 @@ contributes:
         - icon: github
           href: "https://github.com/steno-aarhus/"
           aria-label: "GitHub icon: Link to SDCA GitHub organization page"
-        - icon: twitter
-          href: "https://twitter.com/StenoAarhusRes"
-          aria-label: "Twitter icon: Link to SDCA Twitter page"
         - icon: globe
           href: directory.qmd
           aria-label: "Globe icon: Link to directory page of other SDCA websites"


### PR DESCRIPTION
Since SDCA doesn’t use Twitter/X anymore, this link isn’t relevant.

Closes #16 