### PR TITLE
feat: :sparkles: add wip announcement above navbar with `TODO` to remove when ready

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,6 +6,13 @@ website:
   title: "SDCA website template"
   site-url: "https://steno-aarhus.github.io/REPO-NAME/"
   repo-url: "https://github.com/steno-aarhus/REPO-NAME"
+  
+  # TODO: Remove announcement when website is ready
+  announcement: 
+    icon: info-circle
+    content: "This website is a work in progress and might contain some incomplete or placeholder content."
+    type: light
+  
   navbar:
     tools:
       - icon: github

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,7 +10,7 @@ website:
   # TODO: Remove announcement when website is ready
   announcement: 
     icon: info-circle
-    content: "This website is a work in progress and might contain some incomplete or placeholder content."
+    content: "This website is a work in progress and might contain incomplete or placeholder content."
     type: light
   
   navbar:


### PR DESCRIPTION
Multiple people at Steno have asked about adding content "before the website is ready" (e.g., wanting a "test" repo" to check content before pushing to the website), so I thought adding a WIP announcement might do the trick. 